### PR TITLE
Investigate API quota error

### DIFF
--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -125,7 +125,7 @@ export const codeAgentFunction = inngest.createFunction(
         system: PROMPT,
         model: openai({
           apiKey: process.env.OPENAI_API_KEY,
-          model: "gpt-4.1",
+          model: "gpt-3.5-turbo",
           defaultParameters: {
             temperature: 0.1,
           },


### PR DESCRIPTION
Change OpenAI model to `gpt-3.5-turbo` to resolve 'insufficient_quota' errors.

The user's OpenAI account with a $5 budget likely does not have access to or sufficient quota for `gpt-4.1`, leading to API errors. Switching to `gpt-3.5-turbo` is a common workaround for free trial accounts.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-57b2d23e-5265-452a-a7ea-5cd29fb9f447) · [Cursor](https://cursor.com/background-agent?bcId=bc-57b2d23e-5265-452a-a7ea-5cd29fb9f447)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)